### PR TITLE
Add mic/camera controls and cleanup video resources

### DIFF
--- a/resources/js/Pages/Contacts.vue
+++ b/resources/js/Pages/Contacts.vue
@@ -38,9 +38,18 @@ const callUser = () => {
 
 const endCall = () => {
     peerCall.value?.close();
+    // stop and release any active media tracks
     localStream.value?.getTracks().forEach((track) => track.stop());
-    remoteVideo.value = null;
-    localVideo.value = null;
+    if (localVideo.value?.srcObject) {
+        localVideo.value.srcObject.getTracks().forEach((t) => t.stop());
+        localVideo.value.srcObject = null;
+    }
+    if (remoteVideo.value?.srcObject) {
+        remoteVideo.value.srcObject.getTracks().forEach((t) => t.stop());
+        remoteVideo.value.srcObject = null;
+    }
+    localStream.value = null;
+    peerCall.value = null;
     isCalling.value = false;
     isMuted.value = false;
     cameraOff.value = false;
@@ -164,6 +173,7 @@ onMounted(() => {
 
 onBeforeUnmount(() => {
     window.Echo.leave(`video-call.${auth.user.id}`);
+    endCall();
 });
 
 const acceptCall = () => {
@@ -253,65 +263,68 @@ const declineCall = () => {
                     <!-- Contact Header -->
                     <div class="p-4 border-b border-gray-200 flex items-center">
                         <div class="w-12 h-12 bg-blue-200 rounded-full"></div>
-                        <div class="ml-4">
-                            <div class="font-bold">
-                                {{ selectedUser?.name }}
-                                <button
-                                    v-if="!isCalling"
-                                    @click="callUser"
-                                    class="ml-4 px-4 py-2 bg-blue-500 text-white rounded-lg hover:bg-blue-600"
-                                >
-                                    Call
-                                </button>
-                                <template v-else>
-                                    <button
-                                        @click="toggleMic"
-                                        class="ml-4 px-4 py-2 bg-gray-200 rounded-lg hover:bg-gray-300"
-                                    >
-                                        {{ isMuted ? "Unmute" : "Mute" }}
-                                    </button>
-                                    <button
-                                        @click="toggleCamera"
-                                        class="ml-2 px-4 py-2 bg-gray-200 rounded-lg hover:bg-gray-300"
-                                    >
-                                        {{
-                                            cameraOff
-                                                ? "Show Camera"
-                                                : "Hide Camera"
-                                        }}
-                                    </button>
-                                    <button
-                                        @click="endCall"
-                                        class="ml-4 px-4 py-2 bg-red-500 text-white rounded-lg hover:bg-red-600"
-                                    >
-                                        End Call
-                                    </button>
-                                </template>
-                            </div>
-                        </div>
+                        <div class="ml-4 font-bold flex-1">{{ selectedUser?.name }}</div>
+                        <button
+                            v-if="!isCalling"
+                            @click="callUser"
+                            class="px-4 py-2 bg-blue-500 text-white rounded-lg hover:bg-blue-600"
+                        >
+                            Call
+                        </button>
                     </div>
 
                     <div
                         class="flex-1 overflow-y-auto p-4 space-y-4 bg-gray-50 relative"
                     >
                         <template v-if="isCalling">
-                            <video
-                                id="remoteVideo"
-                                ref="remoteVideo"
-                                autoplay
-                                playsinline
-                                muted
-                                class="border-2 border-gray-800 w-full"
-                            ></video>
-                            <video
-                                id="localVideo"
-                                ref="localVideo"
-                                autoplay
-                                playsinline
-                                muted
-                                class="m-0 border-2 border-gray-800 absolute top-6 right-6 w-4/12"
-                                style="margin: 0"
-                            ></video>
+                            <div class="relative h-full w-full">
+                                <video
+                                    id="remoteVideo"
+                                    ref="remoteVideo"
+                                    autoplay
+                                    playsinline
+                                    muted
+                                    class="border-2 border-gray-800 w-full h-full object-cover"
+                                ></video>
+                                <div class="absolute bottom-4 right-4 w-1/4 border-2 border-gray-800">
+                                    <video
+                                        id="localVideo"
+                                        ref="localVideo"
+                                        autoplay
+                                        playsinline
+                                        muted
+                                        class="w-full h-full object-cover"
+                                    ></video>
+                                    <div
+                                        v-if="cameraOff"
+                                        class="absolute inset-0 bg-black/60 text-white flex items-center justify-center text-sm"
+                                    >
+                                        Camera Off
+                                    </div>
+                                </div>
+                                <div
+                                    class="absolute bottom-4 left-1/2 -translate-x-1/2 flex space-x-4 bg-white/70 rounded-lg p-2"
+                                >
+                                    <button
+                                        @click="toggleMic"
+                                        class="px-3 py-2 rounded-full bg-gray-200 hover:bg-gray-300"
+                                    >
+                                        {{ isMuted ? 'Unmute' : 'Mute' }}
+                                    </button>
+                                    <button
+                                        @click="toggleCamera"
+                                        class="px-3 py-2 rounded-full bg-gray-200 hover:bg-gray-300"
+                                    >
+                                        {{ cameraOff ? 'Show' : 'Hide' }}
+                                    </button>
+                                    <button
+                                        @click="endCall"
+                                        class="px-3 py-2 rounded-full bg-red-500 text-white hover:bg-red-600"
+                                    >
+                                        End
+                                    </button>
+                                </div>
+                            </div>
                         </template>
                         <div
                             v-if="!isCalling"


### PR DESCRIPTION
## Summary
- update `endCall` to fully stop camera/mic streams
- close call cleanly when leaving Contacts page
- reorganise call controls below the video and improve layout
- show overlay when camera is disabled

## Testing
- `npm run build` *(fails: vite not found)*
- `phpunit` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_b_6853ce1a88e4832cb37a6da8bc3a0782