### PR TITLE
Implement live chat feature

### DIFF
--- a/app/Events/NewChatMessage.php
+++ b/app/Events/NewChatMessage.php
@@ -1,0 +1,27 @@
+<?php
+
+namespace App\Events;
+
+use App\Models\ChatMessage;
+use Illuminate\Broadcasting\Channel;
+use Illuminate\Broadcasting\InteractsWithSockets;
+use Illuminate\Broadcasting\PrivateChannel;
+use Illuminate\Contracts\Broadcasting\ShouldBroadcastNow;
+use Illuminate\Foundation\Events\Dispatchable;
+use Illuminate\Queue\SerializesModels;
+
+class NewChatMessage implements ShouldBroadcastNow
+{
+    use Dispatchable, InteractsWithSockets, SerializesModels;
+
+    public function __construct(public ChatMessage $message)
+    {
+    }
+
+    public function broadcastOn(): array
+    {
+        return [
+            new PrivateChannel("chat.{$this->message->receiver_id}"),
+        ];
+    }
+}

--- a/app/Http/Controllers/ChatController.php
+++ b/app/Http/Controllers/ChatController.php
@@ -1,0 +1,51 @@
+<?php
+
+namespace App\Http\Controllers;
+
+use App\Events\NewChatMessage;
+use App\Models\ChatMessage;
+use App\Models\User;
+use Illuminate\Http\Request;
+use Illuminate\Support\Facades\Auth;
+use Inertia\Inertia;
+
+class ChatController extends Controller
+{
+    public function index()
+    {
+        $users = User::where('id', '!=', Auth::id())->get();
+        return Inertia::render('Chat', [
+            'users' => $users,
+        ]);
+    }
+
+    public function messages(User $user)
+    {
+        $messages = ChatMessage::where(function ($q) use ($user) {
+            $q->where('sender_id', Auth::id())
+                ->where('receiver_id', $user->id);
+        })->orWhere(function ($q) use ($user) {
+            $q->where('sender_id', $user->id)
+                ->where('receiver_id', Auth::id());
+        })->orderBy('created_at')->get();
+
+        return response()->json($messages);
+    }
+
+    public function sendMessage(Request $request, User $user)
+    {
+        $request->validate([
+            'message' => 'required|string',
+        ]);
+
+        $message = ChatMessage::create([
+            'sender_id' => Auth::id(),
+            'receiver_id' => $user->id,
+            'content' => $request->input('message'),
+        ]);
+
+        broadcast(new NewChatMessage($message))->toOthers();
+
+        return response()->json($message);
+    }
+}

--- a/app/Models/ChatMessage.php
+++ b/app/Models/ChatMessage.php
@@ -1,0 +1,27 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+
+class ChatMessage extends Model
+{
+    use HasFactory;
+
+    protected $fillable = [
+        'sender_id',
+        'receiver_id',
+        'content',
+    ];
+
+    public function sender()
+    {
+        return $this->belongsTo(User::class, 'sender_id');
+    }
+
+    public function receiver()
+    {
+        return $this->belongsTo(User::class, 'receiver_id');
+    }
+}

--- a/database/migrations/2025_06_19_000000_create_chat_messages_table.php
+++ b/database/migrations/2025_06_19_000000_create_chat_messages_table.php
@@ -1,0 +1,24 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::create('chat_messages', function (Blueprint $table) {
+            $table->id();
+            $table->foreignId('sender_id')->constrained('users');
+            $table->foreignId('receiver_id')->constrained('users');
+            $table->text('content');
+            $table->timestamps();
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::dropIfExists('chat_messages');
+    }
+};

--- a/resources/js/Layouts/AuthenticatedLayout.vue
+++ b/resources/js/Layouts/AuthenticatedLayout.vue
@@ -43,6 +43,12 @@ const showingNavigationDropdown = ref(false);
                                 >
                                     Contacts
                                 </NavLink>
+                                <NavLink
+                                    :href="route('chat')"
+                                    :active="route().current('chat')"
+                                >
+                                    Chat
+                                </NavLink>
                             </div>
                         </div>
 
@@ -155,6 +161,12 @@ const showingNavigationDropdown = ref(false);
                             :active="route().current('contacts')"
                         >
                             Contacts
+                        </ResponsiveNavLink>
+                        <ResponsiveNavLink
+                            :href="route('chat')"
+                            :active="route().current('chat')"
+                        >
+                            Chat
                         </ResponsiveNavLink>
                     </div>
 

--- a/resources/js/Pages/Chat.vue
+++ b/resources/js/Pages/Chat.vue
@@ -1,0 +1,116 @@
+<script setup>
+import AuthenticatedLayout from "@/Layouts/AuthenticatedLayout.vue";
+import { Head, usePage } from "@inertiajs/vue3";
+import { ref, onMounted, onBeforeUnmount } from "vue";
+import axios from "axios";
+
+const auth = usePage().props.auth;
+const users = usePage().props.users;
+const selectedUser = ref(null);
+const messages = ref([]);
+const newMessage = ref("");
+
+const fetchMessages = (user) => {
+    axios.get(`/chat/messages/${user.id}`).then((res) => {
+        messages.value = res.data;
+    });
+};
+
+const selectUser = (user) => {
+    selectedUser.value = user;
+    fetchMessages(user);
+};
+
+const sendMessage = () => {
+    if (!newMessage.value || !selectedUser.value) return;
+    axios
+        .post(`/chat/messages/${selectedUser.value.id}`, {
+            message: newMessage.value,
+        })
+        .then((res) => {
+            messages.value.push(res.data);
+            newMessage.value = "";
+        });
+};
+
+const connectWebSocket = () => {
+    window.Echo.private(`chat.${auth.user.id}`).listen(
+        "NewChatMessage",
+        (e) => {
+            if (
+                selectedUser.value &&
+                (e.message.sender_id === selectedUser.value.id ||
+                    e.message.receiver_id === selectedUser.value.id)
+            ) {
+                messages.value.push(e.message);
+            }
+        }
+    );
+};
+
+onMounted(connectWebSocket);
+onBeforeUnmount(() => {
+    window.Echo.leave(`chat.${auth.user.id}`);
+});
+</script>
+
+<template>
+    <Head title="Chat" />
+    <AuthenticatedLayout>
+        <div class="h-screen flex bg-gray-100 mx-auto max-w-7xl sm:px-6 lg:px-8" style="height: 90vh">
+            <div class="w-1/4 bg-white border-r border-gray-200">
+                <div class="p-4 bg-gray-100 font-bold text-lg border-b border-gray-200">Users</div>
+                <div class="p-4 space-y-4">
+                    <div
+                        v-for="(user, key) in users"
+                        :key="key"
+                        @click="selectUser(user)"
+                        :class="[
+                            'flex items-center p-2 hover:bg-blue-500 hover:text-white rounded cursor-pointer',
+                            user.id === selectedUser?.id ? 'bg-blue-500 text-white' : '',
+                        ]"
+                    >
+                        <div class="w-12 h-12 bg-blue-200 rounded-full"></div>
+                        <div class="ml-4">
+                            <div class="font-semibold">{{ user.name }}</div>
+                        </div>
+                    </div>
+                </div>
+            </div>
+            <div class="flex flex-col w-3/4">
+                <div v-if="!selectedUser" class="h-full flex justify-center items-center text-gray-800 font-bold">
+                    Select User
+                </div>
+                <template v-else>
+                    <div class="p-4 border-b border-gray-200 flex items-center">
+                        <div class="w-12 h-12 bg-blue-200 rounded-full"></div>
+                        <div class="ml-4 font-bold flex-1">{{ selectedUser?.name }}</div>
+                    </div>
+                    <div class="flex-1 overflow-y-auto p-4 space-y-2 bg-gray-50">
+                        <div v-for="(msg, i) in messages" :key="i" :class="msg.sender_id === auth.user.id ? 'text-right' : 'text-left'">
+                            <span
+                                :class="[
+                                    'inline-block px-3 py-2 rounded-lg',
+                                    msg.sender_id === auth.user.id
+                                        ? 'bg-blue-500 text-white'
+                                        : 'bg-white border',
+                                ]"
+                                >{{ msg.content }}</span
+                            >
+                        </div>
+                    </div>
+                    <div class="p-4 border-t border-gray-200 flex space-x-2">
+                        <input
+                            v-model="newMessage"
+                            @keyup.enter="sendMessage"
+                            type="text"
+                            placeholder="Type your message"
+                            class="flex-1 border rounded px-3 py-2"
+                        />
+                        <button @click="sendMessage" class="bg-blue-500 text-white px-4 py-2 rounded">Send</button>
+                    </div>
+                </template>
+            </div>
+        </div>
+    </AuthenticatedLayout>
+</template>

--- a/routes/channels.php
+++ b/routes/channels.php
@@ -9,3 +9,7 @@ use Illuminate\Support\Facades\Broadcast;
 Broadcast::channel('video-call.{id}', function ($user, $id) {
     return (int) $user->id === (int) $id;
 });
+
+Broadcast::channel('chat.{id}', function ($user, $id) {
+    return (int) $user->id === (int) $id;
+});

--- a/routes/web.php
+++ b/routes/web.php
@@ -2,6 +2,7 @@
 
 use App\Http\Controllers\ProfileController;
 use App\Http\Controllers\VideoCallController;
+use App\Http\Controllers\ChatController;
 use App\Models\User;
 use Illuminate\Foundation\Application;
 use Illuminate\Support\Facades\Auth;
@@ -25,6 +26,12 @@ Route::get('/contacts', function () {
     $users = User::where('id', '!=', Auth::user()->id)->get();
     return Inertia::render('Contacts', ['users' => $users]);
 })->middleware(['auth', 'verified'])->name('contacts');
+
+Route::middleware(['auth', 'verified'])->group(function () {
+    Route::get('/chat', [ChatController::class, 'index'])->name('chat');
+    Route::get('/chat/messages/{user}', [ChatController::class, 'messages']);
+    Route::post('/chat/messages/{user}', [ChatController::class, 'sendMessage']);
+});
 
 Route::middleware('auth')->group(function () {
     Route::get('/profile', [ProfileController::class, 'edit'])->name('profile.edit');


### PR DESCRIPTION
## Summary
- add `ChatMessage` model and migration
- implement `ChatController` and websocket event
- expose chat broadcasting channel
- add Inertia page for chatting
- show "Chat" in navigation and wire routes

## Testing
- `php artisan test` *(fails: php not installed)*

------
https://chatgpt.com/codex/tasks/task_b_6853de8129e4832ca4d0750946816586